### PR TITLE
refactor: add members

### DIFF
--- a/src/baby_jubjub.rs
+++ b/src/baby_jubjub.rs
@@ -2,7 +2,7 @@
 //!
 //! This is an append to the the `ark-ed-on-bn254` crate to use the EIP-2494 defined Baby Jubjub curve parameters.
 //!
-//! - https://eips.ethereum.org/EIPS/eip-2494
+//! - <https://eips.ethereum.org/EIPS/eip-2494>
 //!
 //! - Base field: q = 21888242871839275222246405745257275088548364400416034343698204186575808495617
 //! - Scalar field: r = 2736030358979909402780800718157159386076813972158567259200215660948447373041

--- a/src/group.rs
+++ b/src/group.rs
@@ -108,9 +108,9 @@ impl Group {
     }
 
     /// Adds a set of members to the group
-    pub fn add_members(&mut self, members: Vec<Element>) -> Result<(), SemaphoreError> {
-        for member in &members {
-            if *member == EMPTY_ELEMENT {
+    pub fn add_members(&mut self, members: &[Element]) -> Result<(), SemaphoreError> {
+        for &member in members {
+            if member == EMPTY_ELEMENT {
                 return Err(SemaphoreError::EmptyLeaf);
             }
         }
@@ -282,7 +282,7 @@ mod tests {
         let member1 = [1; 32];
         let member2 = [2; 32];
 
-        group.add_members(vec![member1, member2]).unwrap();
+        group.add_members(&[member1, member2]).unwrap();
 
         assert_eq!(group.size(), 2);
     }
@@ -293,7 +293,7 @@ mod tests {
         let member1 = [1; 32];
         let zero = [0u8; ELEMENT_SIZE];
 
-        let result = group.add_members(vec![member1, zero]);
+        let result = group.add_members(&[member1, zero]);
 
         assert!(result.is_err());
         assert_eq!(result, Err(SemaphoreError::EmptyLeaf));
@@ -305,7 +305,7 @@ mod tests {
         let member2 = [2; 32];
         let mut group = Group::default();
 
-        group.add_members(vec![member1, member2]).unwrap();
+        group.add_members(&[member1, member2]).unwrap();
         let index = group.index_of(member2);
 
         assert_eq!(index, Some(1));
@@ -317,7 +317,7 @@ mod tests {
         let member2 = [2; 32];
         let mut group = Group::default();
 
-        group.add_members(vec![member1, member2]).unwrap();
+        group.add_members(&[member1, member2]).unwrap();
 
         group.update_member(0, member1).unwrap();
         assert_eq!(group.size(), 2);
@@ -332,7 +332,7 @@ mod tests {
         let member2 = [2; 32];
         let mut group = Group::default();
 
-        group.add_members(vec![member1, member2]).unwrap();
+        group.add_members(&[member1, member2]).unwrap();
         group.remove_member(0).unwrap();
 
         let result = group.update_member(0, member1);
@@ -346,7 +346,7 @@ mod tests {
         let member2 = [2; 32];
         let mut group = Group::default();
 
-        group.add_members(vec![member1, member2]).unwrap();
+        group.add_members(&[member1, member2]).unwrap();
         group.remove_member(0).unwrap();
 
         let members = group.members();
@@ -360,7 +360,7 @@ mod tests {
         let member2 = [2; 32];
         let mut group = Group::default();
 
-        group.add_members(vec![member1, member2]).unwrap();
+        group.add_members(&[member1, member2]).unwrap();
         group.remove_member(0).unwrap();
 
         let result = group.remove_member(0);
@@ -375,7 +375,7 @@ mod tests {
         let member2 = [2; 32];
         let mut group = Group::default();
 
-        group.add_members(vec![member1, member2]).unwrap();
+        group.add_members(&[member1, member2]).unwrap();
 
         let proof = group.generate_proof(0).unwrap();
         assert_eq!(proof.leaf, member1);
@@ -387,7 +387,7 @@ mod tests {
         let member2 = [2; 32];
         let mut group = Group::default();
 
-        group.add_members(vec![member1, member2]).unwrap();
+        group.add_members(&[member1, member2]).unwrap();
 
         let proof_0 = group.generate_proof(0).unwrap();
         assert_eq!(Group::verify_proof(&proof_0), true);

--- a/src/group.rs
+++ b/src/group.rs
@@ -115,7 +115,7 @@ impl Group {
             }
         }
 
-        self.tree.insert_many(&members)?;
+        self.tree.insert_many(members)?;
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Semaphore Rust Implementation
 //!
 //! Protocol specifications:
-//! - https://github.com/zkspecs/zkspecs/tree/main/specs/3
+//! - <https://github.com/zkspecs/zkspecs/tree/main/specs/3>
 
 pub mod baby_jubjub;
 pub mod error;

--- a/tests/group.rs
+++ b/tests/group.rs
@@ -71,7 +71,7 @@ mod group {
     use ark_ed_on_bn254::Fq;
     use ark_ff::{BigInteger, PrimeField};
     use num_bigint::BigInt;
-    use semaphore_rs::group::{EMPTY_ELEMENT, Element, Group};
+    use semaphore_rs::group::{Element, Group, EMPTY_ELEMENT};
     use std::str::FromStr;
 
     fn str_to_element(s: &str) -> Element {
@@ -123,7 +123,7 @@ mod group {
     fn add_members() {
         let mut group = Group::default();
         let elements: Vec<Element> = ADDED_MEMBERS.iter().map(|s| str_to_element(s)).collect();
-        group.add_members(elements).unwrap();
+        group.add_members(&elements).unwrap();
 
         let root = group.root().unwrap();
         assert_eq!(leaf_to_str(&root), ADD_MEMBERS_ROOT_STR);
@@ -215,7 +215,7 @@ mod group {
             .map(|s| str_to_element(s))
             .collect();
 
-        group.add_members(initial_elements).unwrap();
+        group.add_members(&initial_elements).unwrap();
         group
             .add_member(str_to_element("400000000000000000000000000000"))
             .unwrap();

--- a/tests/group.rs
+++ b/tests/group.rs
@@ -71,7 +71,7 @@ mod group {
     use ark_ed_on_bn254::Fq;
     use ark_ff::{BigInteger, PrimeField};
     use num_bigint::BigInt;
-    use semaphore_rs::group::{Element, Group, EMPTY_ELEMENT};
+    use semaphore_rs::group::{EMPTY_ELEMENT, Element, Group};
     use std::str::FromStr;
 
     fn str_to_element(s: &str) -> Element {


### PR DESCRIPTION
## Description

This PR optimizes the `add_members` function in `src/group.rs` by changing the input from `Vec<Element>` to `&[Element]`, reducing memory overhead by avoiding vector cloning. Tests in `src/group.rs` and `tests/group.rs` are updated to use slice syntax.

It also fixes clippy and docs warnings.

- **What kind of change?** Performance optimization (refactoring)
- **Current behavior**: `add_members` requires an owned `Vec<Element>`, causing unnecessary cloning.
- **New behavior**: Accepts `&[Element]` slice for efficient reference passing.
- **Breaking change?** Yes, users must update calls to pass slices instead of vectors.

## Related Issue(s)

- Resolves #9 

## Other information

All unit tests pass locally with updated slice syntax. No additional documentation changes needed.

## Checklist

- [x] I have read and understand the [contributor guidelines](https://github.com/semaphore-protocol/semaphore-rs/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/semaphore-protocol/semaphore-rs/blob/main/CODE_OF_CONDUCT.md).
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have run `cargo fmt` without getting any errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.